### PR TITLE
fix case where the tmux server has not been created yet

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -23,7 +23,7 @@ STATUS=$(tmux ls 2>&1)
 
 echo "STATUS: ${STATUS}"
 
-if [ "${STATUS}" = "no server running on /tmp/tmux-1000/default" ] ; then
+if [ "${STATUS}" = "no server running on /tmp/tmux-1000/default" ] || [ "${STATUS}" = "error connecting to /tmp/tmux-1000/default (No such file or directory)" ] || [ "${STATUS}" = "error connecting to /tmp//tmux-1000/default (No such file or directory)" ] ; then
     echo "no tmux instance"
     setupApplication
 else


### PR DESCRIPTION
the double slash in `/tmp//tmux-1000/default` happens when `tmux ls` is first run. please pardon me for the re-pull request